### PR TITLE
chore: stop using "os-homedir" package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 var path = require('path');
-var osHomedir = require('os-homedir');
-var home = osHomedir();
+var home = require('os').homedir();
 
 module.exports = function (str) {
 	str = path.normalize(str) + path.sep;

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "user",
     "expand"
   ],
-  "dependencies": {
-    "os-homedir": "^1.0.0"
-  },
   "devDependencies": {
     "ava": "*",
     "xo": "*"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=2.3.0"
   },
   "scripts": {
     "test": "xo && ava"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tildify",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Convert an absolute path to a tilde path: `/Users/sindresorhus/dev` → `~/dev`",
   "license": "MIT",
   "repository": "sindresorhus/tildify",


### PR DESCRIPTION
As you know, the `os-homedir` package is deprecated.

I also bumped the minimum `node` version, as well as the major version of `tildify`.